### PR TITLE
Add support for nullable reference types in properties

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/src/LazyCoder/BaseCoder.cs
+++ b/src/LazyCoder/BaseCoder.cs
@@ -156,8 +156,8 @@ namespace LazyCoder
             switch (csTypeMember)
             {
                 case CsProperty csProperty:
-                    var forceNullable = csProperty.Attributes
-                                                  .Any(a => a.Name.Contains("CanBeNull"));
+                    var forceNullable = csProperty.Attributes.Any(a => a.Name.Contains("CanBeNull"))
+                                        || csProperty.IsNullable;
                     return new TsPropertySignature
                            {
                                Name = csProperty.Name,

--- a/src/LazyCoder/CSharp/CsClass.cs
+++ b/src/LazyCoder/CSharp/CsClass.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 namespace LazyCoder.CSharp
 {

--- a/src/LazyCoder/CSharp/CsInterface.cs
+++ b/src/LazyCoder/CSharp/CsInterface.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 namespace LazyCoder.CSharp
 {

--- a/src/LazyCoder/CSharp/CsProperty.cs
+++ b/src/LazyCoder/CSharp/CsProperty.cs
@@ -3,5 +3,6 @@ namespace LazyCoder.CSharp
     public class CsProperty: CsTypeMember
     {
         public CsType Type { get; set; }
+        public bool IsNullable { get; set; }
     }
 }

--- a/src/LazyCoder/CSharp/CsTypeMember.cs
+++ b/src/LazyCoder/CSharp/CsTypeMember.cs
@@ -7,7 +7,6 @@ namespace LazyCoder.CSharp
         public string Name { get; set; }
         public bool IsStatic { get; set; }
         public bool IsInherited { get; set; }
-        public bool IsNullable { get; set; }
         public CsAccessModifier AccessModifier { get; set; }
         public CsAttribute[] Attributes { get; set; } = Array.Empty<CsAttribute>();
     }

--- a/src/LazyCoder/CSharp/CsTypeMember.cs
+++ b/src/LazyCoder/CSharp/CsTypeMember.cs
@@ -7,6 +7,7 @@ namespace LazyCoder.CSharp
         public string Name { get; set; }
         public bool IsStatic { get; set; }
         public bool IsInherited { get; set; }
+        public bool IsNullable { get; set; }
         public CsAccessModifier AccessModifier { get; set; }
         public CsAttribute[] Attributes { get; set; } = Array.Empty<CsAttribute>();
     }

--- a/src/LazyCoder/CsDeclarationFactory.cs
+++ b/src/LazyCoder/CsDeclarationFactory.cs
@@ -168,8 +168,7 @@ namespace LazyCoder
                                                           })
                                              .ToArray(),
                        Type = new CsType(fieldInfo.FieldType),
-                       Value = GetLiteral(fieldInfo.FieldType),
-                       IsNullable = info.ReadState == NullabilityState.Nullable
+                       Value = GetLiteral(fieldInfo.FieldType)
                    };
         }
 

--- a/src/LazyCoder/CsDeclarationFactory.cs
+++ b/src/LazyCoder/CsDeclarationFactory.cs
@@ -149,6 +149,8 @@ namespace LazyCoder
                 return null;
             }
 
+            var context = new NullabilityInfoContext();
+            var info = context.Create(fieldInfo);
             return new CsField
                    {
                        Name = fieldInfo.Name,
@@ -166,7 +168,8 @@ namespace LazyCoder
                                                           })
                                              .ToArray(),
                        Type = new CsType(fieldInfo.FieldType),
-                       Value = GetLiteral(fieldInfo.FieldType)
+                       Value = GetLiteral(fieldInfo.FieldType),
+                       IsNullable = info.ReadState == NullabilityState.Nullable
                    };
         }
 
@@ -213,6 +216,8 @@ namespace LazyCoder
                 return null;
             }
 
+            var context = new NullabilityInfoContext();
+            var info = context.Create(propertyInfo);
             return new CsProperty
                    {
                        Name = propertyInfo.Name,
@@ -229,7 +234,8 @@ namespace LazyCoder
                                                                  OriginalType = x.AttributeType
                                                              })
                                                 .ToArray(),
-                       Type = new CsType(propertyInfo.PropertyType)
+                       Type = new CsType(propertyInfo.PropertyType),
+                       IsNullable = info.ReadState == NullabilityState.Nullable
                    };
         }
 

--- a/src/LazyCoder/DefaultCoder.cs
+++ b/src/LazyCoder/DefaultCoder.cs
@@ -1,6 +1,3 @@
-using LazyCoder.CSharp;
-using LazyCoder.Typescript;
-
 namespace LazyCoder
 {
     public class DefaultCoder: BaseCoder

--- a/src/LazyCoder/LazyCoder.csproj
+++ b/src/LazyCoder/LazyCoder.csproj
@@ -2,9 +2,10 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>9</LangVersion>
+        <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
         <Version>0.03.12</Version>
+        <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
 </Project>

--- a/src/LazyCoder/LazyCoder.csproj
+++ b/src/LazyCoder/LazyCoder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>
         <Version>0.03.12</Version>

--- a/src/LazyCoder/Typescript/TsTypeReference.cs
+++ b/src/LazyCoder/Typescript/TsTypeReference.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using LazyCoder.CSharp;
 
 namespace LazyCoder.Typescript

--- a/tests/LazyCoder.Tests/LazyCoder.Tests.csproj
+++ b/tests/LazyCoder.Tests/LazyCoder.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <LangVersion>9</LangVersion>
         <Nullable>enable</Nullable>

--- a/tests/LazyCoder.Tests/LazyCoder.Tests.csproj
+++ b/tests/LazyCoder.Tests/LazyCoder.Tests.csproj
@@ -3,8 +3,9 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <LangVersion>9</LangVersion>
+        <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/LazyCoder.Tests/Samples/Literals/Simple.cs
+++ b/tests/LazyCoder.Tests/Samples/Literals/Simple.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.Contracts;
-using System.Linq;
+﻿using System.Linq;
 using Shouldly;
 using Xunit;
 

--- a/tests/LazyCoder.Tests/Samples/Simple/FirstClass.ts
+++ b/tests/LazyCoder.Tests/Samples/Simple/FirstClass.ts
@@ -3,5 +3,6 @@ import { SecondClass } from "./Simple/SecondClass";
 
 export interface FirstClass {
     StringProperty: string;
+    StringNullableProperty: (string | null);
     SecondClassProperty: SecondClass;
 }

--- a/tests/LazyCoder.Tests/Samples/Simple/Simple.cs
+++ b/tests/LazyCoder.Tests/Samples/Simple/Simple.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -69,7 +68,7 @@ namespace LazyCoder.Tests.Samples.Simple
                               .Select(p => new TsPropertySignature
                                            {
                                                Name = p.Name,
-                                               Type = TsType.From(p.Type),
+                                               Type = TsType.From(p.Type, p.IsNullable),
                                                Optional = false
                                            })
                               .ToArray();
@@ -79,6 +78,7 @@ namespace LazyCoder.Tests.Samples.Simple
         private class FirstClass
         {
             public string StringProperty { get; set; }
+            public string? StringNullableProperty { get; set; }
             public SecondClass SecondClassProperty { get; set; }
         }
 


### PR DESCRIPTION
Currently nullability of property is defined by CanBeNull attribute. It is redundant for nullable reference types, however in previous versions of .NET information about nullable reference types was hidden from reflection.

Based on https://devblogs.microsoft.com/dotnet/announcing-net-6-preview-7/#libraries-reflection-apis-for-nullability-information I have added support for nullable reference types in properties. It is possible to add support to nullable reference types in fields (based on same API with NullabilityInfoContext), but it will require greater changes.